### PR TITLE
Added Expansion Rules for Region Claim Actions

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -1420,7 +1420,10 @@ def resolve_claim_actions(game_id: str, actions_list: list[ClaimAction]) -> None
             nation.action_log.append(f"Failed to claim {action.target_region} due to the Widespread Civil Disorder event.")
             continue
 
-        # TODO - minimum spend check
+        minimum_spend[nation.id] += region.calculate_region_claim_cost(nation)
+        if float(nation.get_stockpile("Dollars")) - minimum_spend < 0:
+            nation.action_log.append(f"Failed to claim {region.region_id}. Insufficient dollars.")
+            continue
 
         claim_actions_grouped[nation.id][region.region_id] = region
 
@@ -1506,7 +1509,7 @@ def _validate_all_claims(nation_id: str, claimed_regions: dict[str, Region]) -> 
         cost = region.calculate_region_claim_cost(nation)
         if float(nation.get_stockpile("Dollars")) - cost < 0:
             # nation could not afford region
-            nation.action_log.append(f"Failed to claim {region.region_id}. Insufficient resources.")
+            nation.action_log.append(f"Failed to claim {region.region_id}. Insufficient dollars.")
             failed.add(region.region_id)
         else:
             # region successfully paid for

--- a/app/actions.py
+++ b/app/actions.py
@@ -1421,7 +1421,7 @@ def resolve_claim_actions(game_id: str, actions_list: list[ClaimAction]) -> None
             continue
 
         minimum_spend[nation.id] += region.calculate_region_claim_cost(nation)
-        if float(nation.get_stockpile("Dollars")) - minimum_spend < 0:
+        if float(nation.get_stockpile("Dollars")) - minimum_spend[nation.id] < 0:
             nation.action_log.append(f"Failed to claim {region.region_id}. Insufficient dollars.")
             continue
         

--- a/app/actions.py
+++ b/app/actions.py
@@ -1627,9 +1627,9 @@ def _validate_claim_action(nation_id: str, target_region: Region, adj_owned: set
             # populate queue with adjacent unclaimed regions
             for adj_region_id in target_region.graph.adjacent_regions:
                 adj_region = Region(adj_region_id)
+                visited.add(adj_region_id)
                 if adj_region.data.owner_id != "0":
                     continue
-                visited.add(adj_region_id)
                 queue.append(adj_region)
 
             while queue:
@@ -1659,12 +1659,12 @@ def _validate_claim_action(nation_id: str, target_region: Region, adj_owned: set
         # TODO - special case - valid with one if first 4 turns only
 
         # special case - valid with one if sea route
-        for adj_region_id in []:
+        for adj_region_id in target_region.graph.sea_routes:
             if adj_region_id in adj_owned:
                 return 0
 
         # special case - valid with one if no other adjacent regions
-        if adj_owned_count == 1 and len(target_region.graph.adjacent_regions) == 1:
+        if adj_owned_count == 1 and len(target_region.graph.map) == 1:
             return 0
         
         # special case - valid with one if all other adjacent regions are unclaimable

--- a/app/nation.py
+++ b/app/nation.py
@@ -626,6 +626,9 @@ class Nation:
     def _resources(self, value: dict) -> None:
         self._data["resources"] = value
 
+    def __lt__(self, other: 'Nation'):
+        return self.name < other.name
+
     def add_gov_tags(self) -> None:
         
         match self.gov:
@@ -860,12 +863,6 @@ class Nation:
             adjustment += int(tag_data.get("Agenda Cost", 0))
         
         return adjustment
-
-    def region_claim_political_power_cost(self) -> float:
-        pp_cost = 0.0
-        for tag_data in self.tags.values():
-            pp_cost += float(tag_data.get("Region Claim Cost", 0))
-        return pp_cost
 
     def calculate_alliance_capacity(self) -> tuple[int, int]:
         

--- a/app/nation.py
+++ b/app/nation.py
@@ -254,11 +254,11 @@ class Nations(metaclass=NationsMeta):
             nation.records.energy_income.append(f"{energy_income_total:.2f}")
 
             development_score = 0
-            development_score += nation.improvement_counts.get("Central Bank", 0)
-            development_score += nation.improvement_counts.get("Research Institute", 0)
-            development_score += nation.improvement_counts.get("Settlement", 0)
-            development_score += nation.improvement_counts.get("City", 3)
-            development_score += nation.improvement_counts.get("Capital", 10)
+            development_score += nation.improvement_counts.get("Central Bank", 0) * 1
+            development_score += nation.improvement_counts.get("Research Institute", 0) * 1
+            development_score += nation.improvement_counts.get("Settlement", 0) * 1
+            development_score += nation.improvement_counts.get("City", 0) * 3
+            development_score += nation.improvement_counts.get("Capital", 0) * 10
             nation.records.development.append(development_score)
 
             military_size = 0

--- a/app/region.py
+++ b/app/region.py
@@ -78,6 +78,15 @@ class Region:
     def __lt__(self, other: 'Region'):
         return self.region_id < other.region_id
     
+    def __hash__(self):
+        return hash(self.region_id)
+
+    def __str__(self):
+        return f"R[{self.region_id}]"
+    
+    def __repr__(self):
+        return self.__str__()
+
     def owned_adjacent_regions(self) -> list:
         owned_adjacent_list = []
         for region_id in self.graph.adjacent_regions:

--- a/app/region.py
+++ b/app/region.py
@@ -479,7 +479,9 @@ class GraphData:
         self.is_significant: bool = d["hasRegionalCapital"]
         self.is_magnified: bool = d["isMagnified"]
         self.is_start: bool = d["randomStartAllowed"]
-        self.adjacent_regions: dict = d["adjacencyMap"]
+        self.map: dict = d.get("adjacencyMap", {})
+        self.sea_routes: dict = d.get("seaRoutes", {})
+        self.adjacent_regions: dict = self.map | self.sea_routes
         self.additional_region_coordinates: list = d["additionalRegionCords"]
         self.improvement_coordinates: list = d["improvementCords"]
         self.unit_coordinates: list = d["unitCords"]

--- a/app/region.py
+++ b/app/region.py
@@ -75,6 +75,9 @@ class Region:
             return self.region_id == other.region_id
         return False
     
+    def __lt__(self, other: 'Region'):
+        return self.region_id < other.region_id
+    
     def owned_adjacent_regions(self) -> list:
         owned_adjacent_list = []
         for region_id in self.graph.adjacent_regions:

--- a/app/region.py
+++ b/app/region.py
@@ -161,6 +161,17 @@ class Region:
         """
         self.claim_list.append(player_id)
 
+    def calculate_region_claim_cost(self, nation: 'Nation'):
+        """
+        Calculates cost of claiming a region for a specific nation.
+        """
+        
+        cost_multiplier = 1.0
+        for tag_data in nation.tags.values():
+            cost_multiplier += float(tag_data.get("Region Claim Cost", 0))
+    
+        return int(self.data.purchase_cost * cost_multiplier)
+
     def set_fallout(self, starting_fallout=4) -> None:
         self.data.fallout = starting_fallout
 

--- a/app/scenario.py
+++ b/app/scenario.py
@@ -20,7 +20,7 @@ class SD_Alliance:
     def __init__(self, d: dict):
         self.required_agenda: str = d["Required Agenda"]
         self.capacity: bool = d.get("Capacity") is not None
-        self.color_theme: str = d["colorTheme"]
+        self.color_theme: str = d["Color Theme"]
         self.description: list = d["Description"]
 
 class SD_Event:

--- a/app/site_functions.py
+++ b/app/site_functions.py
@@ -650,9 +650,9 @@ def get_data_for_nation_sheet(game_id: str, player_id: str) -> dict:
     misc_data = player_information_dict["Misc Info"]
     misc_data.append(f"Owned Regions: {nation.stats.regions_owned}")
     misc_data.append(f"Occupied Regions: {nation.stats.regions_occupied}")
-    misc_data.append(f"Net Income: {nation.records.net_income[-1]:+.2f}")
-    misc_data.append(f"Gross Industrial Income: {nation.records.industrial_income[-1]:+.2f}")
-    misc_data.append(f"Gross Energy Income: {nation.records.energy_income[-1]:+.2f}")
+    misc_data.append(f"Net Income: {nation.records.net_income[-1]}")
+    misc_data.append(f"Gross Industrial Income: {nation.records.industrial_income[-1]}")
+    misc_data.append(f"Gross Energy Income: {nation.records.energy_income[-1]}")
     misc_data.append(f"Development Score: {nation.records.development[-1]}")
     misc_data.append(f"Unique Improvements: {sum(1 for count in nation.improvement_counts.values() if count != 0)}")
     misc_data.append(f"Military Size: {nation.records.military_size[-1]}")

--- a/app/templates/temp_nation_sheet.html
+++ b/app/templates/temp_nation_sheet.html
@@ -259,7 +259,7 @@ pre {
                     <tr>
                         <th style="padding-top:3px">Miscellaneous Information</th>
                     </tr>
-                    {% for key, value in player_information_dict['Misc Info'].items() %}
+                    {% for value in player_information_dict['Misc Info'] %}
                         <tr>
                             <td>{{ value }}</td>
                         </tr>

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -17,7 +17,7 @@ This document is a complete reference for all modifiers that can be attached to 
 | Improvement Income Multiplier| Improvement income increases by given resource-amount pairs (as a percentage). 100% = 1.0| See below.                                                  |
 | Market Buy Price             | Buy price for all resources decreased by specified value (as a percentage). 100% = 1.0   | "Market Buy Modifier": 0.2                                  |
 | Market Sell Price            | Sell price for all resources increased by specified value (as a percentage). 100% = 1.0  | "Market Sell Modifier": 0.2                                 |
-| Region Claim Political Cost  | Claim action political power cost (usually 0) increased by specified value.              | "Region Claim Cost": 1                                      |
+| Region Claim Cost Multiplier | Claim action cost (usually 5) increased by specified value (as a percentage). 100% = 1.0 | "Region Claim Cost": 0.2                                    |
 | Research Category Bonus      | Awards an amount of any 1 resource for completing research in specified categories.      | See below.                                                  |
 | Resource Income              | Resource income increases by specified value.                                            | f"{action.resource_name} Income": 5                         |
 | Resource Rate                | Resource income increases by specified value (as a percentage). 100% = 100.              | f"{action.resource_name} Rate": 20                          |

--- a/maps/china/graph.json
+++ b/maps/china/graph.json
@@ -1331,7 +1331,9 @@
         ],
         "adjacencyMap": {
             "ANSHA": true,
-            "DANDO": true,
+            "DANDO": true
+        },
+        "seaRoutes": {
             "YANTA": true
         }
     },
@@ -1429,10 +1431,12 @@
         ],
         "adjacencyMap": {
             "CHNDE": true,
-            "DONGY": true,
             "LANGF": true,
             "QINHU": true,
             "TIANJ": true
+        },
+        "seaRoutes": {
+            "DONGY": true
         }
     },
     "BEIJI": {
@@ -1743,8 +1747,10 @@
             2246
         ],
         "adjacencyMap": {
-            "DALIA": true,
             "QINGD": true
+        },
+        "seaRoutes": {
+            "DALIA": true
         }
     },
     "DONGY": {
@@ -1765,8 +1771,10 @@
         "adjacencyMap": {
             "BINZH": true,
             "JINAN": true,
-            "TNGSN": true,
             "WEIFA": true
+        },
+        "seaRoutes": {
+            "TNGSN": true
         }
     },
     "HENGS": {
@@ -6224,9 +6232,11 @@
             4519
         ],
         "adjacencyMap": {
-            "HAIKO": true,
             "MAOMI": true,
             "QINZH": true
+        },
+        "seaRoutes": {
+            "HAIKO": true
         }
     },
     "HAIKO": {
@@ -6245,7 +6255,9 @@
             4667
         ],
         "adjacencyMap": {
-            "SANYA": true,
+            "SANYA": true
+        },
+        "seaRoutes": {
             "ZHANJ": true
         }
     },

--- a/maps/united_states/graph.json
+++ b/maps/united_states/graph.json
@@ -523,8 +523,10 @@
         ],
         "adjacencyMap": {
             "EAUCL": true,
-            "NTHMI": true,
             "STEVE": true
+        },
+        "seaRoutes": {
+            "NTHMI": true
         }
     },
     "NTHNH": {
@@ -852,7 +854,9 @@
         ],
         "adjacencyMap": {
             "GRAPI": true,
-            "LANSI": true,
+            "LANSI": true
+        },
+        "seaRoutes": {
             "UPPEN": true
         }
     },
@@ -2365,7 +2369,9 @@
         ],
         "adjacencyMap": {
             "NTHCT": true,
-            "SACRA": true,
+            "SACRA": true
+        },
+        "seaRoutes": {
             "SANFR": true
         }
     },
@@ -2715,8 +2721,10 @@
         "adjacencyMap": {
             "SACRA": true,
             "SANJO": true,
-            "SROSA": true,
             "STOCK": true
+        },
+        "seaRoutes": {
+            "SROSA": true
         }
     },
     "SIENV": {


### PR DESCRIPTION
- Claim Actions are now checked to see if they abide by the expansion rules.
- The order claim actions are entered does not matter, the turn processor uses priority queues to make sure claim actions are always resolved in the correct order.
- Added logic to distinguish sea routes from normal adjacency in order to get this to work.
- If a player encircles unclaimed regions due to a claim action, that player will be forced to buy those regions if nobody else can get to them. Otherwise, the claim action will fail (cost will be refunded though).

NOTE: Expansion rules exception for the first 4 turns still needs to be coded in. Will do this alongside #104.